### PR TITLE
Fix libtiff fetch for consumers (.zip/unzip) and bump to 4.7.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 # must be re-fetched/re-configured by `make deps` in the container.
 .git
 libtiff-src
-tiff-*.tar.xz
+tiff-*.zip
 build
 tiff2pdf/c/tiff2pdf.c
 t2p-test/tifs

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ t2p-test/tifs
 t2p-test/pdfs
 build
 libtiff-src
-tiff-*.tar.xz
+tiff-*.zip
 *.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-golang-build-1.26:latest
 
-# g++ builds libtiff's C++ stream helper; tar/xz fetch and unpack the
-# pinned libtiff release tarball during `make deps`.
+# g++ builds libtiff's C++ stream helper; unzip unpacks the pinned libtiff
+# release archive during `make deps`.
 RUN yum update \
-    && yum install -y g++ tar xz
+    && yum install -y g++ unzip
 
 WORKDIR /go/src
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 # that build this package already ship unzip, whereas xz (and sometimes even
 # gzip) can be absent from a minimal base -- so no downstream image needs an
 # extra decompressor installed just to unpack libtiff.
-LIBTIFF_VERSION=4.7.1
-LIBTIFF_SHA256=af20245c98007a9a0a33fa5491d56a3d7287b796b8dd6ba6ea7f3f60d1b0aa68
+LIBTIFF_VERSION=4.7.2
+LIBTIFF_SHA256=964f5556d97301a8ad63e792bac56b0387e3f5e65972d857fec5a059730dd24c
 LIBTIFF_ARCHIVE=tiff-$(LIBTIFF_VERSION).zip
 LIBTIFF_URL=https://download.osgeo.org/libtiff/$(LIBTIFF_ARCHIVE)
 # extracted, repo-local (git-ignored) libtiff source tree

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # libtiff is pulled from the maintained upstream release (not the abandoned
 # vadz/libtiff GitHub mirror, whose newest tag is from 2017). Pin to a tagged
-# release tarball and verify its SHA256 so the build is reproducible and the
+# release archive and verify its SHA256 so the build is reproducible and the
 # library carries current security fixes.
 # Distributed as the .zip release and extracted with unzip: consumer CI images
 # that build this package already ship unzip, whereas xz (and sometimes even

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@
 # vadz/libtiff GitHub mirror, whose newest tag is from 2017). Pin to a tagged
 # release tarball and verify its SHA256 so the build is reproducible and the
 # library carries current security fixes.
+# Distributed as the .zip release and extracted with unzip: consumer CI images
+# that build this package already ship unzip, whereas xz (and sometimes even
+# gzip) can be absent from a minimal base -- so no downstream image needs an
+# extra decompressor installed just to unpack libtiff.
 LIBTIFF_VERSION=4.7.1
-LIBTIFF_SHA256=b92017489bdc1db3a4c97191aa4b75366673cb746de0dce5d7a749d5954681ba
-LIBTIFF_TARBALL=tiff-$(LIBTIFF_VERSION).tar.xz
-LIBTIFF_URL=https://download.osgeo.org/libtiff/$(LIBTIFF_TARBALL)
+LIBTIFF_SHA256=af20245c98007a9a0a33fa5491d56a3d7287b796b8dd6ba6ea7f3f60d1b0aa68
+LIBTIFF_ARCHIVE=tiff-$(LIBTIFF_VERSION).zip
+LIBTIFF_URL=https://download.osgeo.org/libtiff/$(LIBTIFF_ARCHIVE)
 # extracted, repo-local (git-ignored) libtiff source tree
 LIBTIFF_REL=libtiff-src
 TIFF2PDF_C=tiff2pdf/c/tiff2pdf.c
@@ -49,12 +53,13 @@ test: deps $(TIFF2PDF_C)
 
 getdeps:
 	test -f $(LIBTIFF_REL)/libtiff/tiffio.h || ( \
-	    curl -fsSL -o $(LIBTIFF_TARBALL) $(LIBTIFF_URL) && \
-	    echo "$(LIBTIFF_SHA256)  $(LIBTIFF_TARBALL)" | \
+	    curl -fsSL -o $(LIBTIFF_ARCHIVE) $(LIBTIFF_URL) && \
+	    echo "$(LIBTIFF_SHA256)  $(LIBTIFF_ARCHIVE)" | \
 	        (command -v sha256sum >/dev/null 2>&1 && sha256sum -c - || shasum -a 256 -c -) && \
-	    rm -rf $(LIBTIFF_REL) && mkdir -p $(LIBTIFF_REL) && \
-	    tar xf $(LIBTIFF_TARBALL) -C $(LIBTIFF_REL) --strip-components=1 && \
-	    rm -f $(LIBTIFF_TARBALL) )
+	    rm -rf $(LIBTIFF_REL) tiff-$(LIBTIFF_VERSION) && \
+	    unzip -q $(LIBTIFF_ARCHIVE) && \
+	    mv tiff-$(LIBTIFF_VERSION) $(LIBTIFF_REL) && \
+	    rm -f $(LIBTIFF_ARCHIVE) )
 cleandeps:
 	rm -rf $(LIBTIFF_REL)
 configdeps: getdeps


### PR DESCRIPTION
This PR introduces two changes:

1. **Download libtiff as .zip instead of .tar.xz** — the .tar.xz path needs `xz`, which is missing from some consumer CI images, breaking their build at `tar xf` ("xz: Cannot exec"). Those images already ship `unzip`, whereas neither xz nor gzip is guaranteed, so switch to the .zip release (SHA256 verified) and extract with unzip. No consumer changes needed.
2. **Upgrade libtiff to 4.7.2** — latest patch release.

Tested: clean `make` build + /convert smoke test on both.