### PR TITLE
Update Makefile to work with libtiff 4.7.2 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ $(TIFF2PDF_C): $(LIBTIFF_REL)/tools/tiff2pdf.c
 	# the output enable/disable toggle to the Go I/O layer (see tif_golang.c).
 	sed -e '/^int main(/,/^}/d' \
 	    -e '/^#include "libport.h"/d' \
+	    -e '/^#include "tiff_tools.h"/d' \
 	    -e 's/t2p->outputdisable = 1;/GoOutputDisable((int)(intptr_t)t2p);/' \
 	    -e 's/t2p->outputdisable = 0;/GoOutputEnable((int)(intptr_t)t2p);/' \
 	    < $< > $@.tmp


### PR DESCRIPTION
`libtiff 4.7.2` refactored the CLI tools: `tools/tiff2pdf.c` now `#includes tiff_tools.h` (a tools-dir header used only by the stripped main()), which broke the `cgo` build (not on our include path). 

This PR strips that include in the Makefile sed, mirroring the existing `libport.h` removal. 

Testing: SHA256-verified; clean build + `/convert` smoke test pass.